### PR TITLE
Handle long nets during balancing

### DIFF
--- a/src/db/Setting.h
+++ b/src/db/Setting.h
@@ -35,7 +35,8 @@ public:
     bool fixOpenBySST = true;
 
     // length balancing
-    double lengthBalanceCoeff = 0.0;  // weight for net length balancing penalty
+    double lengthBalanceCoeff = 0.0;    // weight for net length balancing penalty
+    DBU lengthBalanceTolerance = 0;     // tolerance for net wirelength difference
 
     // db
     VerboseLevelT dbVerbose = VerboseLevelT::MIDDLE;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,6 +77,9 @@ void runISPD18Flow(const boost::program_options::variables_map& vm) {
     if (vm.count("lengthBalanceCoeff")) {
         db::setting.lengthBalanceCoeff = vm.at("lengthBalanceCoeff").as<double>();
     }
+    if (vm.count("lengthBalanceTolerance")) {
+        db::setting.lengthBalanceTolerance = vm.at("lengthBalanceTolerance").as<DBU>();
+    }
     // db
     if (vm.count("dbVerbose")) {
         db::setting.dbVerbose = db::VerboseLevelT::_from_string(vm.at("dbVerbose").as<std::string>().c_str());
@@ -181,6 +184,7 @@ int main(int argc, char* argv[]) {
                 ("wrongWayPenaltyCoeff", value<double>())
                 ("fixOpenBySST", value<bool>())
                 ("lengthBalanceCoeff", value<double>())
+                ("lengthBalanceTolerance", value<DBU>())
                 ("dbVerbose", value<std::string>())
                 ("dbUsePoorViaMapThres", value<int>())
                 ("dbPoorWirePenaltyCoeff", value<double>())

--- a/src/multi_net/Router.cpp
+++ b/src/multi_net/Router.cpp
@@ -76,9 +76,13 @@ void Router::run() {
     if (database.hasBalance()) {
         database.updateBalanceTargets();
         std::vector<int> balanceNets;
+        DBU tolerance = db::setting.lengthBalanceTolerance;
         for (const auto& group : database.balanceGroups) {
             for (int idx : group) {
-                if (database.nets[idx].routedWireLength < database.nets[idx].balanceTarget) {
+                DBU wl = database.nets[idx].routedWireLength;
+                DBU target = database.nets[idx].balanceTarget;
+                DBU diff = (wl > target) ? wl - target : target - wl;
+                if (diff > tolerance) {
                     balanceNets.push_back(idx);
                 }
             }


### PR DESCRIPTION
## Summary
- reroute nets with wirelength far from group target to allow both short and long nets to converge
- add configurable tolerance for length balancing

## Testing
- `scripts/build.py -o release` *(fails: Could NOT find Boost)*
- `sudo apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c064306824832096e05993275c3540