### PR TITLE
Remove length balance threshold for MazeRoute cost

### DIFF
--- a/src/single_net/MazeRoute.cpp
+++ b/src/single_net/MazeRoute.cpp
@@ -146,10 +146,8 @@ db::RouteStatus MazeRoute::route(int startPin) {
                     }
                     if (estRemain == std::numeric_limits<DBU>::max()) estRemain = 0;
                     DBU total = newWireLen + estRemain;
-                    if (total < localNet.dbNet.balanceTarget) {
-                        double diff = static_cast<double>(localNet.dbNet.balanceTarget - total);
-                        finalCost += diff * diff * db::setting.lengthBalanceCoeff;
-                    }
+                    double diff = static_cast<double>(total - localNet.dbNet.balanceTarget);
+                    finalCost += diff * diff * db::setting.lengthBalanceCoeff;
                 }
                 if (finalCost < vertexCostUBs[v]) {
                     updateSol(std::make_shared<Solution>(finalCost, newLen, newWireLen,


### PR DESCRIPTION
## Summary
- Penalize nets that exceed the balance target in MazeRoute cost calculation

## Testing
- `scripts/build.py -o release` *(fails: Could NOT find Boost (missing: Boost_INCLUDE_DIR filesystem program_options))*

------
https://chatgpt.com/codex/tasks/task_e_68c0644931a88320bc24e73956fdd658